### PR TITLE
Add 0xb demo bits

### DIFF
--- a/demo/AngryBots/index.html
+++ b/demo/AngryBots/index.html
@@ -101,8 +101,12 @@ window.addEventListener('resize', softFullscreenResizeWebGLRenderTarget);
     progress: (new UnityProgress(canvas)),
   };
 
+  var version = "";
+  if (Wasm && Wasm.experimentalVersion)
+    version = String(Wasm.experimentalVersion);
+
   var xhr = new XMLHttpRequest();
-  xhr.open('GET', 'AngryBots.wasm', true);
+  xhr.open('GET', 'AngryBots' + version + '.wasm', true);
   xhr.responseType = 'arraybuffer';
   xhr.onload = function() {
     Module.wasmBinary = xhr.response;

--- a/demo/AngryBots/index.html
+++ b/demo/AngryBots/index.html
@@ -102,8 +102,9 @@ window.addEventListener('resize', softFullscreenResizeWebGLRenderTarget);
   };
 
   var version = "";
-  if (Wasm && Wasm.experimentalVersion)
+  if (Wasm && Wasm.experimentalVersion) {
     version = String(Wasm.experimentalVersion);
+  }
 
   var xhr = new XMLHttpRequest();
   xhr.open('GET', 'AngryBots' + version + '.wasm', true);


### PR DESCRIPTION
This PR adds a (currently candidate) .wasm binary that matches the 0xb branch binary encoding in [design](https://github.com/WebAssembly/design).  The only thing missing (which I'll upload tomorrow assuming [design/#664](https://github.com/WebAssembly/design/pull/664) is merged) is the `br_table` value.  I confirmed locally that it runs in the three configurations: no wasm (which just has the message), FF nightly (0xa), FF with [patches](https://bugzilla.mozilla.org/show_bug.cgi?id=1263202) (0xb).

Happy to get any feedback and update the PR with new binary bits if any issues are found.  I'll of course wait to confirm this decodes in at least one other engine before merging.  (cc @binji @kripken @sunfishcode )