### PR TITLE
Add default <ul> margin-left

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -6,6 +6,10 @@ h1, h2, h3 {
   margin-top: 30px;
 }
 
+ul {
+  margin-left: 1.5em;
+}
+
 .title {
   margin-top: 40px;
   letter-spacing: -1px;
@@ -39,10 +43,6 @@ table tbody th {
   text-align: left;
   font-weight: normal;
   width: 33%;
-}
-
-.flash ul {
-  margin-left: 30px;
 }
 
 .flash-hide {


### PR DESCRIPTION
Minor CSS change to apply a default margin-left for ul tags on both html pages instead of just the demo.

Before:
![before](https://cloud.githubusercontent.com/assets/195061/14928854/39f83a20-0e0f-11e6-8c56-b49bdd0f1238.png)

After:
![after](https://cloud.githubusercontent.com/assets/195061/14928858/3d6b6c86-0e0f-11e6-8842-85b10ab6e080.png)
