### PR TITLE
make IRC link clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
         <p>Join us:</p>
         <ul>
           <li>in the <a href="https://www.w3.org/community/webassembly/">W3C Community Group</a></li>
-          <li>on IRC: <code>irc://irc.w3.org:6667/#webassembly</code></li>
+          <li>on IRC: <a href="https://kiwiirc.com/client/irc.w3.org/?nick=wasmer-?#webassembly">irc://irc.w3.org:6667/#webassembly</a></li>
           <li>by <a href="https://github.com/WebAssembly/design/blob/master/Contributing.md">contributing</a>!</li>
         </ul>
         <p>The WebAssembly <a href="https://wasm-stat.us/console">waterfall</a> builds, executes, and archives different components of the WebAssembly project, enabling end-to-end integration tests of LLVM compilation and execution in d8 and the Binaryen interpreter.</p>


### PR DESCRIPTION
it takes you to kiwi IRC web client to make it easy for non IRC users to connect and interact.