### PR TITLE
Update demo to 0xD and remove use of Wasm object

### DIFF
--- a/demo/AngryBots/Release/AngryBots.js
+++ b/demo/AngryBots/Release/AngryBots.js
@@ -97,12 +97,13 @@ function integrateWasmJS(Module) {
   };
   info["global.Math"] = global.Math;
   info["env"] = env;
-  if (Wasm.experimentalVersion < 0xc || typeof WebAssembly == "undefined") {
+  if (typeof Wasm != "undefined" && Wasm.experimentalVersion < 0xc) {
     var exports = Wasm.instantiateModule(binary, info).exports;
     mergeMemory(exports.memory);
     applyMappedGlobals();
     return exports;
   }
+
   var exports = new WebAssembly.Instance(new WebAssembly.Module(binary), info).exports;
   mergeMemory(exports.memory.buffer);
   applyMappedGlobals();

--- a/demo/AngryBots/index.html
+++ b/demo/AngryBots/index.html
@@ -95,15 +95,21 @@ window.addEventListener('resize', softFullscreenResizeWebGLRenderTarget);
     codeUrl: "Release/AngryBots.js",
     memUrl: "Release/AngryBots.mem",
     compatibilitycheck: function() {
-      if (typeof Wasm !== 'object') (alert("You need a browser which supports WebAssembly to run this content. See the WebAssembly demo page for instructions."), window.history.back());
+      if (typeof Wasm !== 'object' && typeof WebAssembly !== 'object') (alert("You need a browser which supports WebAssembly to run this content. See the WebAssembly demo page for instructions."), window.history.back());
       hasWebGL ? mobile ? confirm("Please note that Unity WebGL is not currently supported on mobiles. Press Ok if you wish to continue anyway.") || window.history.back() : -1 == browser.indexOf("Firefox") && -1 == browser.indexOf("Chrome") && -1 == browser.indexOf("Safari") && (confirm("Please note that your browser is not currently supported for this Unity WebGL content. Try installing Firefox, or press Ok if you wish to continue anyway.") || window.history.back()) : (alert("You need a browser which supports WebGL to run this content. Try installing Firefox."), window.history.back())
     },
     progress: (new UnityProgress(canvas)),
   };
 
   var version = "";
-  if (Wasm && Wasm.experimentalVersion) {
+  if (typeof Wasm === 'object' && Wasm.experimentalVersion < 0xc) {
     version = String(Wasm.experimentalVersion);
+  } else if (typeof WebAssembly === 'object') {
+    if (WebAssembly.validate(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x0c, 0x00, 0x00, 0x00))) {
+        version = String(0xc);
+    } else if (WebAssembly.validate(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x00, 0x00))) {
+        version = String(0xd);
+    }
   }
 
   var xhr = new XMLHttpRequest();

--- a/demo/index.md
+++ b/demo/index.md
@@ -31,7 +31,7 @@ This is an experimental demo of Angry Bots, a Unity game which has been ported t
 
 <script type="text/javascript" >
 (function() {
-  var support = (typeof Wasm === 'object');
+  var support = (typeof Wasm === 'object') || (typeof WebAssembly === 'object');
   if (!support) {
     var flash = document.getElementById('wasm-fail');
     flash.className = flash.className.replace(/(?:^|\s)flash-hide(?!\S)/, '');


### PR DESCRIPTION
This PR updates the demo to match SM's impl of the 0xD changes on `binary_0xd` branch in the design repo.  It also removes dependence on the `Wasm` object, using `WebAssembly.validate` to detect 0xc vs. 0xd, as discussed in #27.

Feedback welcome of whether this binary can be successfully decoded by other 0xD impls.