### PR TITLE
Change http:// to https:// in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This repository exists to redirect traffic from [webassembly.github.io](http://webassembly.github.io) to [webassembly.org](http://webassembly.org) (now hosted from the [website](https://github.com/WebAssembly/website) repo).
+This repository exists to redirect traffic from [webassembly.github.io](https://webassembly.github.io) to [webassembly.org](https://webassembly.org) (now hosted from the [website](https://github.com/WebAssembly/website) repo).

--- a/demo/AngryBots/index.html
+++ b/demo/AngryBots/index.html
@@ -2,12 +2,12 @@
 <html lang="en-US">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="1;url=http://webassembly.org/demo/AngryBots/">
+    <meta http-equiv="refresh" content="1;url=https://webassembly.org/demo/AngryBots/">
     <script language="javascript">
-        window.location.href = "http://webassembly.org/demo/AngryBots/"
+        window.location.href = "https://webassembly.org/demo/AngryBots/"
     </script>
     <title>Page Redirection</title>
 </head>
 <body>
-If you are not redirected automatically, please click the link to continue to <a href='http://webassembly.org/demo/AngryBots/'>webassembly.org/demo/AngryBots/</a>.
+If you are not redirected automatically, please click the link to continue to <a href='https://webassembly.org/demo/AngryBots/'>webassembly.org/demo/AngryBots/</a>.
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,12 +2,12 @@
 <html lang="en-US">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="1;url=http://webassembly.org/demo/">
+    <meta http-equiv="refresh" content="1;url=https://webassembly.org/demo/">
     <script language="javascript">
-        window.location.href = "http://webassembly.org/demo/"
+        window.location.href = "https://webassembly.org/demo/"
     </script>
     <title>Page Redirection</title>
 </head>
 <body>
-If you are not redirected automatically, please click the link to continue to <a href='http://webassembly.org/demo/'>webassembly.org/demo/</a>.
+If you are not redirected automatically, please click the link to continue to <a href='https://webassembly.org/demo/'>webassembly.org/demo/</a>.
 </body>

--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en-US">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="1;url=http://webassembly.org">
+    <meta http-equiv="refresh" content="1;url=https://webassembly.org">
     <script language="javascript">
-        window.location.href = "http://webassembly.org"
+        window.location.href = "https://webassembly.org"
     </script>
     <title>Page Redirection</title>
 </head>
 <body>
-If you are not redirected automatically, please click the link to continue to <a href='http://webassembly.org'>webassembly.org</a>.
+If you are not redirected automatically, please click the link to continue to <a href='https://webassembly.org'>webassembly.org</a>.
 </body>


### PR DESCRIPTION
Merge this request once [webassembly.org](https://webassembly.org) gains HTTPS support.

GitHub recently [announced that custom domains on GitHub Pages have gained support for HTTPS](https://blog.github.com/2018-05-01-github-pages-custom-domains-https/) and the DNS `A` records for [webassembly.org](https://webassembly.org) are currently in the process of being updated in order to take advantage of this. Track WebAssembly/website#30 to know when the records have been updated.